### PR TITLE
Fix for untagged "is null" check not finding all cases of untagged resources

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: false
 contact_links:
   - name: Questions
-    url: https://steampipe.io/community/join
+    url: https://turbot.com/community/join
     about: GitHub issues in this repository are only intended for bug reports and feature requests. Other issues will be closed. Please ask and answer questions through the Steampipe Slack community.
   - name: Steampipe CLI Bug Reports and Feature Requests
     url: https://github.com/turbot/steampipe/issues/new/choose

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ The benchmark queries use common properties (like `account_id`, `connection_name
 
 If you have an idea for additional controls or just want to help maintain and extend this mod ([or others](https://github.com/topics/steampipe-mod)) we would love you to join the community and start contributing.
 
-- **[Join our Slack community →](https://steampipe.io/community/join)** and hang out with other Mod developers.
+- **[Join #steampipe on Slack → →](https://turbot.com/community/join)** and hang out with other Mod developers.
 
 Please see the [contribution guidelines](https://github.com/turbot/steampipe/blob/main/CONTRIBUTING.md) and our [code of conduct](https://github.com/turbot/steampipe/blob/main/CODE_OF_CONDUCT.md). All contributions are subject to the [Apache 2.0 open source license](https://github.com/turbot/steampipe-mod-aws-tags/blob/main/LICENSE).
 

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ The benchmark queries use common properties (like `account_id`, `connection_name
 
 If you have an idea for additional controls or just want to help maintain and extend this mod ([or others](https://github.com/topics/steampipe-mod)) we would love you to join the community and start contributing.
 
-- **[Join #steampipe on Slack → →](https://turbot.com/community/join)** and hang out with other Mod developers.
+- **[Join #steampipe on Slack →](https://turbot.com/community/join)** and hang out with other Mod developers.
 
 Please see the [contribution guidelines](https://github.com/turbot/steampipe/blob/main/CONTRIBUTING.md) and our [code of conduct](https://github.com/turbot/steampipe/blob/main/CODE_OF_CONDUCT.md). All contributions are subject to the [Apache 2.0 open source license](https://github.com/turbot/steampipe-mod-aws-tags/blob/main/LICENSE).
 

--- a/controls/untagged.sp
+++ b/controls/untagged.sp
@@ -3,11 +3,11 @@ locals {
     select
       arn as resource,
       case
-        when (tags is null or not exists(select 1 from jsonb_object_keys(tags))) then 'alarm'
+        when tags = '{}' or tags is null then 'alarm'
         else 'ok'
       end as status,
       case
-        when (tags is null or not exists(select 1 from jsonb_object_keys(tags))) then title || ' has no tags'
+        when tags = '{}' or tags is null then title || ' has no tags'
         else title || ' has tags.'
       end as reason
       ${local.tag_dimensions_sql}

--- a/controls/untagged.sp
+++ b/controls/untagged.sp
@@ -3,11 +3,11 @@ locals {
     select
       arn as resource,
       case
-        when tags is null then 'alarm'
+        when (tags is null or not exists(select 1 from jsonb_object_keys(tags))) then 'alarm'
         else 'ok'
       end as status,
       case
-        when tags is null then title || ' has no tags.'
+        when (tags is null or not exists(select 1 from jsonb_object_keys(tags))) then title || ' has no tags'
         else title || ' has tags.'
       end as reason
       ${local.tag_dimensions_sql}

--- a/docs/index.md
+++ b/docs/index.md
@@ -175,7 +175,7 @@ The benchmark queries use common properties (like `account_id`, `connection_name
 
 If you have an idea for additional controls or just want to help maintain and extend this mod ([or others](https://github.com/topics/steampipe-mod)) we would love you to join the community and start contributing.
 
-- **[Join our Slack community →](https://steampipe.io/community/join)** and hang out with other Mod developers.
+- **[Join #steampipe on Slack → →](https://turbot.com/community/join)** and hang out with other Mod developers.
 
 Please see the [contribution guidelines](https://github.com/turbot/steampipe/blob/main/CONTRIBUTING.md) and our [code of conduct](https://github.com/turbot/steampipe/blob/main/CODE_OF_CONDUCT.md). All contributions are subject to the [Apache 2.0 open source license](https://github.com/turbot/steampipe-mod-aws-tags/blob/main/LICENSE).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -175,7 +175,7 @@ The benchmark queries use common properties (like `account_id`, `connection_name
 
 If you have an idea for additional controls or just want to help maintain and extend this mod ([or others](https://github.com/topics/steampipe-mod)) we would love you to join the community and start contributing.
 
-- **[Join #steampipe on Slack → →](https://turbot.com/community/join)** and hang out with other Mod developers.
+- **[Join #steampipe on Slack →](https://turbot.com/community/join)** and hang out with other Mod developers.
 
 Please see the [contribution guidelines](https://github.com/turbot/steampipe/blob/main/CONTRIBUTING.md) and our [code of conduct](https://github.com/turbot/steampipe/blob/main/CODE_OF_CONDUCT.md). All contributions are subject to the [Apache 2.0 open source license](https://github.com/turbot/steampipe-mod-aws-tags/blob/main/LICENSE).
 


### PR DESCRIPTION
Checking tags object for is_null is not always sufficient to find resources with no tags.

This commit adds an additional check for keys in the tags object.

Use of SELECT sub-query on jsonb_object_keys(tags)  is consistent with use found in:


- limit.sp: Ln 13
- mandatory.sp: Ln 14
- prohibited.sp: Ln 19

### Checklist
[- [ ] Issue(s) linked] https://github.com/turbot/steampipe-mod-aws-tags/issues/36
